### PR TITLE
sepolicy: Label Dolby Sepolicy labels

### DIFF
--- a/common/private/property_contexts
+++ b/common/private/property_contexts
@@ -3,6 +3,12 @@ vendor.camera.aux.packageexcludelist   u:object_r:vendor_persist_camera_prop:s0
 vendor.camera.aux.packagelist          u:object_r:vendor_persist_camera_prop:s0
 vendor.camera.skip_unconfigure.packagelist  u:object_r:vendor_persist_camera_prop:s0
 
+# Dolby Properties
+ro.vendor.dolby.dax.version            u:object_r:exported_system_prop:s0
+ro.vendor.audio.dolby.dax.support      u:object_r:exported_system_prop:s0
+ro.vendor.audio.dolby.dax.version      u:object_r:exported_system_prop:s0
+ro.vendor.audio.dolby.surround.enable  u:object_r:exported_system_prop:s0
+
 # Radio
 ro.telephony.use_old_mnc_mcc_format    u:object_r:telephony_config_prop:s0
 


### PR DESCRIPTION
- Support | Version | Surround

- This is second part of following changes: Evolution-X/frameworks_av@7efbd5f51dd5e74b4c1197d953469e2f6c36cd0c Evolution-X/frameworks_av@83e80858f3391f144315aa521abb22991ef5300f